### PR TITLE
Update Blazor.md

### DIFF
--- a/src/Website/docs/Blazor.md
+++ b/src/Website/docs/Blazor.md
@@ -140,7 +140,7 @@ or a blazor component as well
 type FooComponent() =
     inherit Component()
 
-    [<CascadingParameter>]
+    [<CascadingParameter(Name = "MeaningOfLife")>]
     member val MeaningOfLife = 0 with get, set
 
     override this.Render() =


### PR DESCRIPTION
For me the CascadingParameter attribute required an explicit name to be parsed correctly to the view (line 124).