### PR TITLE
fix 'Unhandled exception rendering component: Unable to set property …

### DIFF
--- a/src/Website/docs/Blazor.md
+++ b/src/Website/docs/Blazor.md
@@ -73,7 +73,7 @@ Additionally, some parameter types must be handled specially:
     
     let myButton model dispatch =
         comp<MatButton> {
-          attr.callback "OnClick" (fun _ -> dispatch ButtonClicked)
+          on.click (fun _ -> dispatch ButtonClicked)
           "Click me!"
         }
     ```


### PR DESCRIPTION
…'OnClick' on object of type 'MatBlazor.MatButton'. The error was: Specified cast is not valid.', error